### PR TITLE
Fix typo in apt HTTP options

### DIFF
--- a/Dockerfile.bionic
+++ b/Dockerfile.bionic
@@ -28,8 +28,8 @@ RUN apt-get update && \
 		apt-get install \
 		--yes \
 		--no-install-recommends \
-		--option "Acquire:http::No-Cache=true" \
-		--option "Acquire:http::Pipeline-Depth=0" \
+		--option "Acquire::http::No-Cache=true" \
+		--option "Acquire::http::Pipeline-Depth=0" \
 		lambda-stack-cuda \
 		lambda-server && \
 	rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.focal
+++ b/Dockerfile.focal
@@ -28,8 +28,8 @@ RUN apt-get update && \
 		apt-get install \
 		--yes \
 		--no-install-recommends \
-		--option "Acquire:http::No-Cache=true" \
-		--option "Acquire:http::Pipeline-Depth=0" \
+		--option "Acquire::http::No-Cache=true" \
+		--option "Acquire::http::Pipeline-Depth=0" \
 		lambda-stack-cuda \
 		lambda-server && \
 	rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.xenial
+++ b/Dockerfile.xenial
@@ -23,8 +23,8 @@ RUN apt-key add lambda.gpg && \
 		apt-get install \
 		--yes \
 		--no-install-recommends \
-		--option "Acquire:http::No-Cache=true" \
-		--option "Acquire:http::Pipeline-Depth=0" \
+		--option "Acquire::http::No-Cache=true" \
+		--option "Acquire::http::Pipeline-Depth=0" \
 		lambda-stack-cuda \
 		lambda-server && \
 	rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
`-o Debug::Acquire:http=true` wasn't working, but it worked when I added the other `:`.

Maybe this has been causing the issues in the docker containers recently?