### PR TITLE
Update README.md, remove bionic

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Dockerfiles with rolling-release Lambda Stack, designed for use with nvidia-cont
 Build the image with the appropriate command for the distribution you wish to use.
 
 ```
-sudo docker build -t lambda-stack:18.04 -f Dockerfile.bionic .
 sudo docker build -t lambda-stack:20.04 -f Dockerfile.focal .
 sudo docker build -t lambda-stack:22.04 -f Dockerfile.jammy .
 ```


### PR DESCRIPTION
Dockerfile for bionic was removed in 461d601d16e4a32915cb3bd4aecb67d0bae9f95e, delete mention from the README